### PR TITLE
revised brat2rdf to handle brat entity user notes.

### DIFF
--- a/brat2rdf.py
+++ b/brat2rdf.py
@@ -5,52 +5,45 @@ import re
 import os
 import sys
 import json
+import fnmatch
+from pprint import pprint
 from rdflib import ConjunctiveGraph, Graph, Namespace, BNode, URIRef, Literal, RDF, RDFS, OWL, XSD, plugin, query
-
-## Nota Bene: This script assumes that the annotation.conf document in the brat
-## installation will have been changed: the first line of each .txt file should
-## contain a Quotation entity, rather than a QuotationID entity
-
+from rdflib.collection import Collection
 
 vpq = Namespace("http://visibleprices.org/quotation/")
 vps = Namespace("http://visibleprices.org/vp-schema#")
 vp = Namespace("http://visibleprices.org/")
 
-## the 'entities' dictionary is a 'switch' statement:
-## each key calls a function that returns the
-## rdf node appropriate to that entity type
-entities = {
-    "Quotation": lambda x: this,
-    "PriceExpression": lambda x: this + "#" + x,
-    "PricedThing": lambda x: BNode(),
-    "ValueExpression": lambda x: BNode(),
-    "NormalizedValue": lambda x: BNode()
-}
-
-## Parse the brat .ann file into a python dictionary:
+## Parse a single brat .ann file into a python dictionary:
 def ann2dict(annfile):
+    """ Takes a single brat annotation file (.ann), parses each line and generates a dictionary. So far, we're handling only entities 'T', relations 'R', and user annotations '#'. Not here handling brat Events (N-ary relations). The presence of such a structure will break this.
+    """
     anndict = dict()
     for line in annfile:
-        if line[0] == "#":
+        if line[0] == "#": # this sort of user annotation should only exist in document order, AFTER the entity it annotates
             nid, ent_eid, note_string = line.split('\t')
             entity, eid = ent_eid.split(' ', 1)
-            anndict[nid] = {
-                "node": entity,
-                "note_string": note_string,
-                "type": vps[entity]
-            }
-        
+            anndict[eid]["notes"] = note_string
+            
         elif line[0] == 'T':
             eid, ent_and_offsets, text = line.split('\t')
             entity, offsets = ent_and_offsets.split(' ', 1)
             offsets = [list([int(y) for y in x.split()]) for x in offsets.split(';')]
         
-            anndict[eid] = {
-                "type": vps[entity],
-                "offsets": offsets,
-                "text": text,
-                "node": entities[entity](eid)
-            }
+            if entity == "Quotation":
+            # The Quotation entity serves a a proxy for the document as a whole so we're not preserving the offsets.
+                anndict[eid] = {
+                    "type": vps[entity],
+                    "text": quote_txt,
+                    "node": entities[entity](eid)
+                }
+            else:
+                anndict[eid] = {
+                    "type": vps[entity],
+                    "offsets": offsets,
+                    "text": text,
+                    "node": entities[entity](eid)
+                }
             
         elif line[0] == "R":
             rid, prop, a1, a2, note = re.split('\s+', line, maxsplit=4)
@@ -59,49 +52,93 @@ def ann2dict(annfile):
                 "sub": a1.split(':')[1],
                 "obj": a2.split(':')[1],
                 "prop": vps[prop],
-                "note": note if note else None
+                "note": note if note else None # likely to break if relations have notes.
             }
             
     return anndict
     
 def dict2graph(d, g):
+    """ Takes a single dictionary returned from ann2dict, and an existing ConjunctiveGraph (g) and adds triples to the Graph. Again, handling only the brat types T and R (Entity and Relation).
+    """
     for i in d:
         entry = d[i]
         if re.match('T\d+', i):
-            node = entry['node']
-            type = entry["type"]
-            text = entry["text"]
-            offsets = entry["offsets"]
-            g.add(( node, RDF.type, type ))
+            node = entry.get('node')
+            ent_type = entry.get("type")
+            text = entry.get("text")
+            offsets = entry.get("offsets")
+            g.add(( node, RDF.type, ent_type ))
             g.add(( node, vps.textData, Literal(text, datatype=XSD.string) ))
-            g.add(( node, vps.offsets, Literal(str(offsets), datatype=XSD.string) ))
-        
+            if offsets:
+                g.add(( node, vps.offsets, Literal(str(offsets), datatype=XSD.string) ))
+
+            if entry.get("notes"):
+                # Try to parse the 'notes' field as a json object, on ValueError exception,
+                # the notes field will be interpreted as a string and added to the graph
+                # as an rdfs:comment Literal()
+                try:
+                    bibdata = json.loads( entry["notes"] )
+                    for p,o in bibdata.items():
+                        if p == "Keywords":
+                            # This might collide with the UI keyword annotation function
+                            # remember Collection.append() if we need to integrate them.
+                            kwnode = BNode()
+                            kws = [Literal(x.strip(), datatype=XSD.string) for x in o.split(',')]
+                            g.add(( node, vps.keyWords, kwnode ))
+                            c = Collection(g, kwnode, kws)
+                        else:
+                            g.add(( node, vps[re.sub('\s+', '_', p)], Literal(o, datatype=XSD.string) ))
+                            
+                except ValueError:
+                    g.add(( node, RDFS.comment, Literal(entry["notes"], datatype=XSD.string) ))
+                
+                        
         if re.match('R\d+', i):
             s = d[entry['sub']]['node']
             o = d[entry['obj']]['node']
             p = entry['prop']
             g.add(( s,p,o ))
-    
+            
     return g
     
-anngraph = ConjunctiveGraph()
-anngraph.namespace_manager.bind('vps', URIRef("http://visibleprices.org/vp-schema#"))
-anngraph.namespace_manager.bind('vpq', URIRef("http://visibleprices.org/quotation/"))
 
-try:
-    brat_data_path = sys.argv[1]
+if __name__ == "__main__":
 
-    for x in set(os.path.splitext(file)[0] for file in os.listdir(brat_data_path)):
-        ann = open(brat_data_path + x + ".ann", 'r')
-        txt = open(brat_data_path + x + ".txt", 'r').read()
-        qId = re.search("T\d+\tQuotation.*\t(.*)", ann.readline()).group(1)
-        ann.seek(0)
-        this = URIRef(vpq + qId)
-        d = ann2dict(ann)
-        dict2graph(d, anngraph)
-    print anngraph.serialize(format="turtle").replace("\n\"\"\"^^xsd", '"""^^xsd')
+    ## 'entities' dictionary used as a 'switch' statement:
+    ## each key calls a function that returns the
+    ## rdf node appropriate to that entity type.
+    ## So that it might be extended different node types (?)
+    ## or URI constructors.
+    entities = {
+        "Quotation": lambda x: quotation_URI,
+        "PriceExpression": lambda x: quotation_URI + "#" + x,
+        "PricedThing": lambda x: BNode(),
+        "ValueExpression": lambda x: BNode(),
+        "NormalizedValue": lambda x: BNode()
+    }
 
-except: print "usage: python brat2rdf.py /path/to/brat/data/directory/\nThe 'turtle' serialized graph will be written to stdout\nBut you could write it to a file thus:\npython brat2rdf.py /path/to/brat/data/directory/ > /path/to/outfile"
+    anngraph = ConjunctiveGraph()
+    
+    # use namespace_manager to bind namespaces for serialization
+    anngraph.namespace_manager.bind('vp', URIRef("http://visibleprices.org/"))
+    anngraph.namespace_manager.bind('vps', URIRef("http://visibleprices.org/vp-schema#"))
+    anngraph.namespace_manager.bind('vpq', URIRef("http://visibleprices.org/quotation/"))
+
+    try:
+        brat_data_path = "/Users/jjc/Desktop/VP_revised_Jul_8/" #sys.argv[1]
+        for doc in set(os.path.splitext(file)[0] for file in os.listdir(brat_data_path) if file.startswith("VP")):
+            ann = open(brat_data_path + doc + ".ann", 'r')
+            quote_txt = open(brat_data_path + doc + ".txt", 'r').read()
+            qId = re.search("T\d+\tQuotation.*\t(.*)", ann.readline()).group(1)
+            ann.seek(0)
+            quotation_URI = URIRef(vpq + qId)
+            d = ann2dict(ann)
+            dict2graph(d, anngraph)
+        print anngraph.serialize(format="turtle").replace("\n\"\"\"^^xsd", '"""^^xsd')
+
+    except:
+        print sys.exc_info()
+        print "usage: python brat2rdf.py /path/to/brat/data/directory/\nThe 'turtle' serialized graph will be written to stdout\nBut you could write it to a file thus:\npython brat2rdf.py /path/to/brat/data/directory/ > /path/to/outfile"
                 
 ###############################################################################    
     

--- a/csv2brat.py
+++ b/csv2brat.py
@@ -1,32 +1,38 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-#########Download spreadsheet as csv and run this script on the resulting file
-#########to get a bunch of .txt and .ann files that can be uploaded to the brat
-#########installation. The .ann files start out with minimal markup: the
-#########Quotation entity and an AnnotatorNotes element that is a json literal
-#########containing all the other metadata.
+# Download spreadsheet as csv and run this script on the resulting file to get a
+# bunch of .txt and .ann files that can be uploaded to the brat installation. The
+# .ann files start out with minimal markup: the Quotation entity and an
+# AnnotatorNotes element that is a json literal containing all the other metadata.
 
+# TODO: pretty this up for execution from command line, (sys.argv etc.). Right
+# now, just plug the path to the csv file in to the DictReader(); and a path to
+# the directory where you want to write the .txt and .ann files; and provide
+# user feedback for reassurance that something happend.
 
 import csv
 from pprint import pprint
 import json
 
-csvIn = csv.DictReader(open("/Users/jjc/Sites/VisiblePrices/May 2015 VP Data for Jon - Sheet1.csv","rU"))
+path_to_csv = "/Users/jjc/Sites/VisiblePrices/May 2015 VP Data for Jon - Sheet1.csv"
+path_to_brat_data_dir = "/Users/jjc/Sites/VisiblePrices/VP_revised_Jul_8/"
+csvIn = csv.DictReader(open(path_to_csv, 'rU'))
 qno = 1
 
 for x in csvIn:
     # generate the .txt file
     qid = "VPex" + str(qno)
-    txt = open("/Users/jjc/Sites/VisiblePrices/VP_revised_Jul_8/VPex" + str(qno) + ".txt", 'w')
+    txt = open(path_to_brat_data_dir + "VPex" + str(qno) + ".txt", 'w')
     txt.write(qid + "\n" + x["Quote"].replace('"',''))
     txt.close()
 
     # generate the .ann file
-    ann = open("/Users/jjc/Sites/VisiblePrices/VP_revised_Jul_8/VPex" + str(qno) + ".ann", 'w')
+    ann = open(path_to_brat_data_dir + "VPex" + str(qno) + ".ann", 'w')
     
-    #NB: the metadata dicts won't all have the same set of keys so watch out for KeyErrors
-    metadata = {y[0]:y[1] for y in x.items() if y[1] and y[0] != "Quote"} 
+    # NB: the dictionary comprehension, as stated, tests for the existence of values `if i[1]`
+    # so metadata dicts won't all have the same set of keys: watch out for KeyErrors
+    metadata = {i[0]:i[1] for i in x.items() if i[1] and i[0] != "Quote"} 
     ann.write("""T1\tQuotation 0 %d\t%s\n#1\tAnnotatorNotes T1\t%s"""% (len(qid), qid, json.dumps(metadata))) 
     ann.close()
     qno += 1


### PR DESCRIPTION
The brat2rdf script now handles the json literal that we're storing in the annotator's notes field for brat entities. Currently it treats the keys (column headers from your spreadsheet) as vps: predicates, replacing spaces with underscores. When you change the column headers to something like dc:author, or whatever, this is going to need some tweaking. As it stands, however, it generates an rdf graph containing all of your metadata, and correctly generates an rdf:list for your comma separated keywords. It also correctly handles this case: If we just store a simple comment (instead of a json hash of keys and values) in the brat entity's annotator's notes field, the script will add it to the graph as an rdfs:comment.
